### PR TITLE
doc: update fact that version 1 repositories could store data and tre…

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -217,7 +217,7 @@ All other types are invalid, more types may be added in the future. The
 compressed types are only valid for repository format version 2. Data and
 tree blobs may be compressed with the zstandard compression algorithm.
 
-In repository format version 1, data and tree blobs should be stored in
+In repository format version 1, data and tree blobs could be stored in
 separate pack files. In version 2, they must be stored in separate files.
 Compressed and non-compress blobs of the same type may be mixed in a pack
 file.


### PR DESCRIPTION
Update minor fact that version 1 repository index format allowed data blobs and tree blobs to be a part of the same pack file.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://forum.restic.net/t/does-restic-seperate-tree-and-data-into-different-packs-in-the-index-file/6013

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~[ ] I have added tests for all code changes.~ documentation change
- [x] I have added documentation for relevant changes (in the manual).
- ~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~ documentation change
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
